### PR TITLE
修复redis客户端set命令的错误调用

### DIFF
--- a/dns/handler.go
+++ b/dns/handler.go
@@ -103,7 +103,7 @@ func (h *Handler) do(netType string, w dns.ResponseWriter, req *dns.Msg) {
 		_ = w.WriteMsg(m)
 
 		if rmd != "" {
-			err := h.redisClient.Set(rmd, remoteIp.String(), time.Duration(h.setting.SaveTime)*time.Second)
+			err := h.redisClient.Set(rmd, remoteIp.String(), time.Duration(h.setting.SaveTime)*time.Second).Err()
 			if err != nil {
 				log.Error(err)
 			}


### PR DESCRIPTION
redis 客户端set命令时的err获取是错误的调用